### PR TITLE
Some hashes are not initialized.

### DIFF
--- a/lib/trahald/redis-client.rb
+++ b/lib/trahald/redis-client.rb
@@ -16,6 +16,8 @@ module Trahald
       @redis = Redis.new(:url => url)
       @pages = Hash.new
       @summary_redis = SummaryRedis.new(@redis, SUMMARY_KEY, 50)
+      @status_add = Hash.new;
+      @remove_add = Hash.new;
     end
 
     def article(name)


### PR DESCRIPTION
This causes errors on ruby 2.1.0.

```
NoMethodError - undefined method `[]=' for nil:NilClass:
        /Users/iwai/WebstormProjects/trahald-fix/lib/trahald/redis-client.rb:28:in `add!'
        /Users/iwai/WebstormProjects/trahald-fix/lib/trahald.rb:185:in `block in <class:App>'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:1293:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:1293:in `block in compile!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:860:in `[]'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:860:in `block (3 levels) in route!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:876:in `route_eval'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:860:in `block (2 levels) in route!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:897:in `block in process_route'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:895:in `catch'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:895:in `process_route'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:859:in `block in route!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:858:in `each'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:858:in `route!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:963:in `block in dispatch!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:946:in `block in invoke'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:946:in `catch'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:946:in `invoke'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:960:in `dispatch!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:794:in `block in call!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:946:in `block in invoke'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:946:in `catch'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:946:in `invoke'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:794:in `call!'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:780:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/nulllogger.rb:9:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:124:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:1417:in `block in call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:1499:in `synchronize'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/sinatra-1.3.6/lib/sinatra/base.rb:1417:in `call'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/handler/webrick.rb:60:in `service'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/2.1.0/webrick/httpserver.rb:94:in `run'
        /Users/iwai/.rbenv/versions/2.1.0/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread'
```
